### PR TITLE
Add building and container recipes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION "3.24")
+
+project("Exercise")
+
+find_package(Boost REQUIRED COMPONENTS container filesystem)
+
+find_package(deal.II 9.5.0 REQUIRED)
+deal_ii_initialize_cached_variables()
+
+find_package(yaml-cpp REQUIRED)
+
+add_library(flatset flatset/flatset.cpp)
+target_link_libraries(flatset PRIVATE Boost::container)
+
+add_library(filesystem filesystem/filesystem.cpp)
+target_link_libraries(filesystem PRIVATE Boost::filesystem)
+
+add_library(fem fem/fem.cpp)
+deal_ii_setup_target(fem)
+
+add_library(yamlParser yamlParser/yamlParser.cpp)
+target_link_libraries(yamlParser PRIVATE ${YAML_CPP_LIBRARIES})
+
+add_executable(main main.cpp)
+target_link_libraries(main PRIVATE flatset filesystem fem yamlParser)
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:24.04
+
+# Install Build-essential packages and then clear APT cache to ensure minimal image size
+# (this increases build time, but that would practically outweigh the increased download time for each user)
+RUN apt-get update ; \
+    apt-get install -y build-essential cmake make unzip wget ; \
+    apt-get install -y libboost-all-dev libdeal.ii-dev ;\
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Add libyaml from source in the required version
+ADD https://github.com/jbeder/yaml-cpp/archive/refs/tags/yaml-cpp-0.6.3.zip /tmp/yaml-cpp.zip
+RUN cd /tmp ; \
+    unzip /tmp/yaml-cpp.zip ; \
+    cd /tmp/yaml-cpp-yaml-cpp-0.6.3 ; \
+    mkdir build ; cd build ; \
+    cmake -DYAML_BUILD_SHARED_LIBS=ON .. ; \
+    make -j$(nproc) install ; \
+    cd / ; \
+    rm -rf /tmp/*
+
+# Add our source code directly to the image. Can also be mounted. Depends on use-case
+COPY . /cmake-exercise

--- a/main.cpp
+++ b/main.cpp
@@ -1,39 +1,39 @@
-//#include "fem/fem.hpp"
-//#include "flatset/flatset.hpp"
-//#include "filesystem/filesystem.hpp"
-//#include "yamlParser/yamlParser.hpp"
+#include "fem/fem.hpp"
+#include "flatset/flatset.hpp"
+#include "filesystem/filesystem.hpp"
+#include "yamlParser/yamlParser.hpp"
 #include <iostream>
 
 int main(int argc, char *argv[])
 {
   std::cout << "Let's fight with CMake, Docker, and some dependencies!" << std::endl << std::endl;
 
-  //std::cout << "Solve Poisson problem with FEM using deal.II" << std::endl;
-  //Fem fem;
-  //fem.run();
-  //std::cout << std::endl;
+  std::cout << "Solve Poisson problem with FEM using deal.II" << std::endl;
+  Fem fem;
+  fem.run();
+  std::cout << std::endl;
 
-  //std::cout << "Modify a flat set using boost container" << std::endl;
-  //modifyAndPrintSets();
-  //std::cout << std::endl;
+  std::cout << "Modify a flat set using boost container" << std::endl;
+  modifyAndPrintSets();
+  std::cout << std::endl;
 
-  //std::cout << "Inspect the current directory using boost filesystem" << std::endl;
-  //inspectDirectory();
-  //std::cout << std::endl;
+  std::cout << "Inspect the current directory using boost filesystem" << std::endl;
+  inspectDirectory();
+  std::cout << std::endl;
 
   
-  //if ( argc == 2 )
-  //{
-  //  const std::string yamlFile( argv[1] );
-  //  std::cout << "Parse some yaml file with yaml-cpp" << std::endl;
-  //  std::cout << "  " << yamlFile << std::endl;
-  //  parseConfig( yamlFile );
-  //}
-  //else
-  //{
-  //  std::cout << "To parse a yaml file please specify file on command line" << std::endl;
-  //  std::cout << "  ./main YAMLFILE" << std::endl;
-  //}
+  if ( argc == 2 )
+  {
+    const std::string yamlFile( argv[1] );
+    std::cout << "Parse some yaml file with yaml-cpp" << std::endl;
+    std::cout << "  " << yamlFile << std::endl;
+    parseConfig( yamlFile );
+  }
+  else
+  {
+    std::cout << "To parse a yaml file please specify file on command line" << std::endl;
+    std::cout << "  ./main YAMLFILE" << std::endl;
+  }
 
   return 0;
 }

--- a/multistage.Dockerfile
+++ b/multistage.Dockerfile
@@ -1,0 +1,59 @@
+FROM ubuntu:24.04 AS build
+
+# Install Build-dependencies. We do not need to clear the apt cache, since this build-image 
+# is separate from the image shipping to the user.
+# We install fixed versions for boost here, so the build env matches the runtime env later.
+# For deal.ii that is not available. For this exercise I will accept that.
+# For a real deployment the real solution might be to install from source as well.
+RUN apt-get update ; \
+    apt-get install -y build-essential cmake make unzip wget ; \
+    apt-get install -y libboost1.83-all-dev libdeal.ii-dev
+
+# Add libyaml from source in the required version
+ADD https://github.com/jbeder/yaml-cpp/archive/refs/tags/yaml-cpp-0.6.3.zip /tmp/yaml-cpp.zip
+RUN cd /tmp ; \
+    unzip /tmp/yaml-cpp.zip ; \
+    cd /tmp/yaml-cpp-yaml-cpp-0.6.3 ; \
+    mkdir build ; cd build ; \
+    cmake -DYAML_BUILD_SHARED_LIBS=ON .. ; \
+    make -j$(nproc) install
+
+RUN mkdir -p /work
+COPY . /work
+
+RUN cd /work ; \
+    mkdir -p build-docker ; \
+    cd build-docker ; \
+    cmake -DCMAKE_BUILD_TYPE=Release .. ; \
+    make -j$(nproc) ; \
+    tar -czf main.tar.gz $(find . -type f \( -iname main -o -iname \*.so \))
+
+FROM ubuntu:24.04 as run
+
+# Install the runtime dependencies only (so no -dev packages).
+# These are only available with fixed versions, so we use them (which also benefits stability)
+# We also need libsundials-nvecserial6 explicitly for some reason. If not installed here, it is missing.
+RUN apt-get update ; \
+    apt-get install -y build-essential cmake unzip ; \
+    apt-get install -y libdeal.ii-9.5.1 libboost-container1.83.0 libboost-filesystem1.83.0 libsundials-nvecserial6 ; \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Add libyaml from source in the required version.
+ADD https://github.com/jbeder/yaml-cpp/archive/refs/tags/yaml-cpp-0.6.3.zip /tmp/yaml-cpp.zip
+RUN cd /tmp ; \
+    unzip /tmp/yaml-cpp.zip ; \
+    cd /tmp/yaml-cpp-yaml-cpp-0.6.3 ; \
+    mkdir build ; cd build ; \
+    cmake -DYAML_BUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release .. ; \
+    make -j$(nproc) install ; \
+    cd / ; \
+    rm -rf /tmp/*
+
+# Remove build dependencies for yaml-cpp again.
+RUN apt-get remove -y build-essential cmake unzip ; apt-get -y autoremove
+
+RUN mkdir -p /opt/exercise
+COPY --from=build /work/build-docker/main.tar.gz /opt/exercise/main.tar.gz
+RUN cd /opt/exercise ; tar -xzf main.tar.gz ; rm main.tar.gz
+
+CMD /opt/exercise/main


### PR DESCRIPTION
Submission by krampfkn

I can not assign myself to this PR, since I do not have the permission on GitHub to do so.

As addition to the regular task (`main.cpp`, `Dockerfile` and `CMakeLists.txt`) I also created a second Dockerfile `multistage.Dockerfile`.

That second file contains a multistage build recipe which builds the software and then adds the compiled executable and the runtime dependencies to a fresh image. The resulting image is ~1 GB smaller than with all build dependencies.

This would be a common case when shipping software to be executed by an end user (not development resources).